### PR TITLE
A couple changes I had to make to get the Pixlee object to work in my project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This can be installed via Composer. Or you can include Pixlee.php in your source
 
 Usage
 ==================
-$pixlee = Pixlee.new(pixlee_api_key, pixlee_secret_key, pixlee_user_id)
+$pixlee = new Pixlee(pixlee_api_key, pixlee_secret_key, pixlee_user_id)
 
 **Getting  your albums**
 

--- a/src/Pixlee.php
+++ b/src/Pixlee.php
@@ -74,9 +74,16 @@ class Pixlee{
 	}
 
 	private function signedData($data){
+
+		//Fix for php versions that don't support JSON_UNESCAPED_SLASHES (< php 5.4)
+		if(defined("JSON_UNESCAPED_SLASHES"))
+			$jsonData = json_encode($data, JSON_UNESCAPED_SLASHES);
+		else
+			$jsonData = str_replace('\\/', '/', json_encode($data));
+
 		$payload 				= array('data' 			=> $data, 
 														'api_key' 	=> $this->apiKey,
-														'signature' => hash_hmac('sha256', json_encode($data, JSON_UNESCAPED_SLASHES),  $this->secretKey));
+														'signature' => hash_hmac('sha256', $jsonData,  $this->secretKey));
 		$payload 				= json_encode($payload);
 		return $payload;
 	}
@@ -93,7 +100,7 @@ class Pixlee{
 		}elseif ( is_null( $theResult->status ) ){
 			throw new Exception('Pixlee did not return a status');
 		}elseif( !$this->isBetween( $theResult->status, 200, 299 ) ){
-			$errorMessage 	=	implode(',', $theResult->message);
+			$errorMessage 	=	implode(',', (array)$theResult->message);
 			throw new Exception("$theResult->status - $errorMessage ");
 		}else{
 			return $theResult;


### PR DESCRIPTION
Corrected the example in the Readme for creating a new pixlee object. 

The json_encode JSON_UNESCAPED_SLASHES option doesn't exist in php < 5.4 so I added a hacky work around for creating the escaped string.  

I now cast the error message as an array so the implode returns because it was returning an empty value if $theResult->message was not an array.
